### PR TITLE
Disable IP address resolution for clients from a different DNS domain

### DIFF
--- a/codjo-security-server/src/test/java/net/codjo/security/server/login/AuthenticationBehaviourTest.java
+++ b/codjo-security-server/src/test/java/net/codjo/security/server/login/AuthenticationBehaviourTest.java
@@ -219,6 +219,62 @@ public class AuthenticationBehaviourTest extends BehaviourTestCase {
     }
 
 
+    public void test_badIpControlRejectFrenchClient() throws Exception {
+        configureAgents(DEFAULT_SERVER_VERSION);
+        authenticationBehaviour.setIpResolver(new AuthenticationBehaviour.IpResolver() {
+            public String resolve(String ipAddress) {
+                return "A7WA284.am.agf.fr";
+            }
+        });
+        authenticationBehaviour.action();
+        LoginEvent loginEvent = sendMessageToServerLoginAgent(
+              createLoginMessage(LOGIN,
+                                 PASSWORD,
+                                 null,
+                                 DEFAULT_SERVER_VERSION,
+                                 "142.12.12.12",
+                                 "localhost",
+                                 SecurityLevel.USER));
+        assertTrue(loginEvent.hasFailed());
+    }
+
+
+    public void test_badIpControlAcceptForeignClient() throws Exception {
+        configureAgents(DEFAULT_SERVER_VERSION);
+        authenticationBehaviour.setIpResolver(new AuthenticationBehaviour.IpResolver() {
+            public String resolve(String ipAddress) {
+                return "A7_FOREIGN_WS";
+            }
+        });
+        authenticationBehaviour.action();
+        LoginEvent loginEvent = sendMessageToServerLoginAgent(
+              createLoginMessage(LOGIN,
+                                 PASSWORD,
+                                 null,
+                                 DEFAULT_SERVER_VERSION,
+                                 "183.12.12.12",
+                                 "localhost",
+                                 SecurityLevel.USER));
+        assertFalse(loginEvent.hasFailed());
+    }
+//
+//    public void test_bidon() throws Exception {
+//        InetAddress byName = InetAddress.getByName("142.134.65.72");
+//        System.out.println("byName = " + byName);
+//        InetAddress a7WA284 = InetAddress.getByName("A7WA284.am.agf.fr");
+//        System.out.println("a7WA284.isSiteLocalAddress() = " + a7WA284.isSiteLocalAddress());
+//        System.out.println("a7WA284 = " + a7WA284);
+//        System.out.println("byNameCanon = " + byName.getCanonicalHostName());
+//        System.out.println("a7WA284Canon = " + a7WA284.getCanonicalHostName());
+//
+//        InetAddress a7lb009 = InetAddress.getByName("A7LB009");
+//        InetAddress deutch = InetAddress.getByName("183.55.43.73");
+//        System.out.println("isLocal = " + deutch.isSiteLocalAddress());
+//        System.out.println("a7lb009 = " + a7lb009.getCanonicalHostName());
+//        System.out.println("deutch.getCanonicalHostName() = " + deutch.getCanonicalHostName());
+//    }
+
+
     @Override
     protected void doSetUp() throws MalformedURLException {
         serviceHelperMock = new SecurityServiceHelperMock(logString);

--- a/codjo-security-server/src/test/java/net/codjo/security/server/login/AuthenticationBehaviourTest.java
+++ b/codjo-security-server/src/test/java/net/codjo/security/server/login/AuthenticationBehaviourTest.java
@@ -257,22 +257,6 @@ public class AuthenticationBehaviourTest extends BehaviourTestCase {
                                  SecurityLevel.USER));
         assertFalse(loginEvent.hasFailed());
     }
-//
-//    public void test_bidon() throws Exception {
-//        InetAddress byName = InetAddress.getByName("142.134.65.72");
-//        System.out.println("byName = " + byName);
-//        InetAddress a7WA284 = InetAddress.getByName("A7WA284.am.agf.fr");
-//        System.out.println("a7WA284.isSiteLocalAddress() = " + a7WA284.isSiteLocalAddress());
-//        System.out.println("a7WA284 = " + a7WA284);
-//        System.out.println("byNameCanon = " + byName.getCanonicalHostName());
-//        System.out.println("a7WA284Canon = " + a7WA284.getCanonicalHostName());
-//
-//        InetAddress a7lb009 = InetAddress.getByName("A7LB009");
-//        InetAddress deutch = InetAddress.getByName("183.55.43.73");
-//        System.out.println("isLocal = " + deutch.isSiteLocalAddress());
-//        System.out.println("a7lb009 = " + a7lb009.getCanonicalHostName());
-//        System.out.println("deutch.getCanonicalHostName() = " + deutch.getCanonicalHostName());
-//    }
 
 
     @Override


### PR DESCRIPTION
## Context

Users can't connect to applications if they launch their client in a different DNS domain from the server one.
## Description

A few years ago, an IP control has been added to prevent issues yielded by client having weird dynamic Ip.

This control, works well if the client and the server are in the same DNS domain, but if the DNS are different, it prevent any client to connect to the server.

To allow foreign clients to connect to the server we modified the `hasGoodIpResolution` control.
