### PR TITLE
Bug Fix - Disable IP address resolution for clients from a different DNS domain

### DIFF
--- a/codjo-security-server/src/main/java/net/codjo/security/server/login/AuthenticationBehaviour.java
+++ b/codjo-security-server/src/main/java/net/codjo/security/server/login/AuthenticationBehaviour.java
@@ -14,6 +14,7 @@ import net.codjo.security.common.login.LoginAction;
 import net.codjo.security.common.login.LoginEvent;
 import net.codjo.security.common.login.LoginProtocol;
 import net.codjo.security.server.api.SecurityServiceHelper;
+import net.codjo.util.network.IpValidator;
 import org.apache.log4j.Logger;
 
 import static net.codjo.agent.AclMessage.OBJECT_LANGUAGE;
@@ -125,7 +126,7 @@ class AuthenticationBehaviour extends CyclicBehaviour {
                              && expectedHostName.equals(actualHostName);
             if (!result) {
                 LOG.warn("Expected host name: " + expectedHostName + ", actual host name: " + actualHostName);
-                if (!expectedHostName.contains(".")) {
+                if (IpValidator.isValid(expectedHostName)) {
                     LOG.warn(
                           "Ip resolution ignored since hostname is not resolved by dns server: " + ip + ", host name: "
                           + hostname);

--- a/codjo-security-server/src/test/java/net/codjo/security/server/login/AuthenticationBehaviourTest.java
+++ b/codjo-security-server/src/test/java/net/codjo/security/server/login/AuthenticationBehaviourTest.java
@@ -212,7 +212,7 @@ public class AuthenticationBehaviourTest extends BehaviourTestCase {
                                  PASSWORD,
                                  null,
                                  DEFAULT_SERVER_VERSION,
-                                 "255.0.0.1",
+                                 "xxx.0.0.1",
                                  "localhost",
                                  SecurityLevel.USER));
         assertTrue(loginEvent.hasFailed());
@@ -243,7 +243,7 @@ public class AuthenticationBehaviourTest extends BehaviourTestCase {
         configureAgents(DEFAULT_SERVER_VERSION);
         authenticationBehaviour.setIpResolver(new AuthenticationBehaviour.IpResolver() {
             public String resolve(String ipAddress) {
-                return "A7_FOREIGN_WS";
+                return "183.12.12.12";
             }
         });
         authenticationBehaviour.action();

--- a/codjo-security-server/src/test/resources/net/codjo/security/server/dependency.txt
+++ b/codjo-security-server/src/test/resources/net/codjo/security/server/dependency.txt
@@ -11,6 +11,7 @@ net.codjo.security.server.login
 	-> net.codjo.plugin.common.session
 	-> net.codjo.security.common.login
 	-> net.codjo.security.server.api
+	-> net.codjo.util.network
 
 net.codjo.security.server.model
 	-> net.codjo.security.common.api


### PR DESCRIPTION
## Context

The following modification did not work properly: https://github.com/codjo/codjo-security/pull/4.
## Description

The ip control has been modified to be less restrictive.
