### PR TITLE
Disabled IP coherence test in production code

### DIFF
--- a/codjo-security-server/src/main/java/net/codjo/security/server/login/AuthenticationBehaviour.java
+++ b/codjo-security-server/src/main/java/net/codjo/security/server/login/AuthenticationBehaviour.java
@@ -71,18 +71,18 @@ class AuthenticationBehaviour extends CyclicBehaviour {
             return;
         }
 
-        String clientIP = action.getIp();
+//        String clientIP = action.getIp();
         String clientHostname = action.getHostname();
         if (clientHostname != null && isLaptop(clientHostname)) {
             LOG.info("Laptop detected '" + action);
         }
-        if (clientIP != null && clientHostname != null && !hasGoodIpResolution(clientIP, clientHostname)) {
-            InvalidIPHostnameException invalidIPHostnameException
-                  = new InvalidIPHostnameException(clientIP, clientHostname);
-            LOG.warn(invalidIPHostnameException.getMessage());
-            sendReplyMessage(myACLMessage, new LoginEvent(invalidIPHostnameException));
-            return;
-        }
+//        if (clientIP != null && clientHostname != null && !hasGoodIpResolution(clientIP, clientHostname)) {
+//            InvalidIPHostnameException invalidIPHostnameException
+//                  = new InvalidIPHostnameException(clientIP, clientHostname);
+//            LOG.warn(invalidIPHostnameException.getMessage());
+//            sendReplyMessage(myACLMessage, new LoginEvent(invalidIPHostnameException));
+//            return;
+//        }
 
         try {
             LOG.info("Trying to login with (user: " + action.getLogin() + ", securityLevel: "

--- a/codjo-security-server/src/test/java/net/codjo/security/server/login/AuthenticationBehaviourTest.java
+++ b/codjo-security-server/src/test/java/net/codjo/security/server/login/AuthenticationBehaviourTest.java
@@ -16,6 +16,7 @@ import net.codjo.security.common.login.LoginProtocol;
 import net.codjo.security.server.api.SecurityServiceHelperMock;
 import net.codjo.security.server.api.SessionManagerMock;
 import net.codjo.test.common.LogString;
+import org.junit.Ignore;
 /**
  *
  */
@@ -204,39 +205,39 @@ public class AuthenticationBehaviourTest extends BehaviourTestCase {
     }
 
 
-    public void test_clientWithInvalidIPHostname() throws Exception {
-        configureAgents(DEFAULT_SERVER_VERSION);
-        authenticationBehaviour.action();
-        LoginEvent loginEvent = sendMessageToServerLoginAgent(
-              createLoginMessage(LOGIN,
-                                 PASSWORD,
-                                 null,
-                                 DEFAULT_SERVER_VERSION,
-                                 "xxx.0.0.1",
-                                 "localhost",
-                                 SecurityLevel.USER));
-        assertTrue(loginEvent.hasFailed());
-    }
-
-
-    public void test_badIpControlRejectFrenchClient() throws Exception {
-        configureAgents(DEFAULT_SERVER_VERSION);
-        authenticationBehaviour.setIpResolver(new AuthenticationBehaviour.IpResolver() {
-            public String resolve(String ipAddress) {
-                return "A7WA284.am.agf.fr";
-            }
-        });
-        authenticationBehaviour.action();
-        LoginEvent loginEvent = sendMessageToServerLoginAgent(
-              createLoginMessage(LOGIN,
-                                 PASSWORD,
-                                 null,
-                                 DEFAULT_SERVER_VERSION,
-                                 "142.12.12.12",
-                                 "localhost",
-                                 SecurityLevel.USER));
-        assertTrue(loginEvent.hasFailed());
-    }
+//    public void test_clientWithInvalidIPHostname() throws Exception {
+//        configureAgents(DEFAULT_SERVER_VERSION);
+//        authenticationBehaviour.action();
+//        LoginEvent loginEvent = sendMessageToServerLoginAgent(
+//              createLoginMessage(LOGIN,
+//                                 PASSWORD,
+//                                 null,
+//                                 DEFAULT_SERVER_VERSION,
+//                                 "xxx.0.0.1",
+//                                 "localhost",
+//                                 SecurityLevel.USER));
+//        assertTrue(loginEvent.hasFailed());
+//    }
+//
+//
+//    public void test_badIpControlRejectFrenchClient() throws Exception {
+//        configureAgents(DEFAULT_SERVER_VERSION);
+//        authenticationBehaviour.setIpResolver(new AuthenticationBehaviour.IpResolver() {
+//            public String resolve(String ipAddress) {
+//                return "A7WA284.am.agf.fr";
+//            }
+//        });
+//        authenticationBehaviour.action();
+//        LoginEvent loginEvent = sendMessageToServerLoginAgent(
+//              createLoginMessage(LOGIN,
+//                                 PASSWORD,
+//                                 null,
+//                                 DEFAULT_SERVER_VERSION,
+//                                 "142.12.12.12",
+//                                 "localhost",
+//                                 SecurityLevel.USER));
+//        assertTrue(loginEvent.hasFailed());
+//    }
 
 
     public void test_badIpControlAcceptForeignClient() throws Exception {


### PR DESCRIPTION
## Context

German users can't connect to French applications.
## Description

The coherence test between IP resolution and client hostname has been disabled (French servers don't know German hosts, it throws an `UnknownHostException`).
