### PR TITLE
Remove unused code (deactivated IP control)

### DIFF
--- a/codjo-security-server/src/test/java/net/codjo/security/server/login/AuthenticationBehaviourTest.java
+++ b/codjo-security-server/src/test/java/net/codjo/security/server/login/AuthenticationBehaviourTest.java
@@ -16,7 +16,6 @@ import net.codjo.security.common.login.LoginProtocol;
 import net.codjo.security.server.api.SecurityServiceHelperMock;
 import net.codjo.security.server.api.SessionManagerMock;
 import net.codjo.test.common.LogString;
-import org.junit.Ignore;
 /**
  *
  */
@@ -205,48 +204,8 @@ public class AuthenticationBehaviourTest extends BehaviourTestCase {
     }
 
 
-//    public void test_clientWithInvalidIPHostname() throws Exception {
-//        configureAgents(DEFAULT_SERVER_VERSION);
-//        authenticationBehaviour.action();
-//        LoginEvent loginEvent = sendMessageToServerLoginAgent(
-//              createLoginMessage(LOGIN,
-//                                 PASSWORD,
-//                                 null,
-//                                 DEFAULT_SERVER_VERSION,
-//                                 "xxx.0.0.1",
-//                                 "localhost",
-//                                 SecurityLevel.USER));
-//        assertTrue(loginEvent.hasFailed());
-//    }
-//
-//
-//    public void test_badIpControlRejectFrenchClient() throws Exception {
-//        configureAgents(DEFAULT_SERVER_VERSION);
-//        authenticationBehaviour.setIpResolver(new AuthenticationBehaviour.IpResolver() {
-//            public String resolve(String ipAddress) {
-//                return "A7WA284.am.agf.fr";
-//            }
-//        });
-//        authenticationBehaviour.action();
-//        LoginEvent loginEvent = sendMessageToServerLoginAgent(
-//              createLoginMessage(LOGIN,
-//                                 PASSWORD,
-//                                 null,
-//                                 DEFAULT_SERVER_VERSION,
-//                                 "142.12.12.12",
-//                                 "localhost",
-//                                 SecurityLevel.USER));
-//        assertTrue(loginEvent.hasFailed());
-//    }
-
-
     public void test_badIpControlAcceptForeignClient() throws Exception {
         configureAgents(DEFAULT_SERVER_VERSION);
-        authenticationBehaviour.setIpResolver(new AuthenticationBehaviour.IpResolver() {
-            public String resolve(String ipAddress) {
-                return "183.12.12.12";
-            }
-        });
         authenticationBehaviour.action();
         LoginEvent loginEvent = sendMessageToServerLoginAgent(
               createLoginMessage(LOGIN,

--- a/codjo-security-server/src/test/resources/net/codjo/security/server/dependency.txt
+++ b/codjo-security-server/src/test/resources/net/codjo/security/server/dependency.txt
@@ -11,7 +11,6 @@ net.codjo.security.server.login
 	-> net.codjo.plugin.common.session
 	-> net.codjo.security.common.login
 	-> net.codjo.security.server.api
-	-> net.codjo.util.network
 
 net.codjo.security.server.model
 	-> net.codjo.security.common.api


### PR DESCRIPTION
### Context

For testing purpose the IP check control had been deactived but the code was still their (see https://github.com/codjo/codjo-security/pull/6).
### Description

The behaviour has been validated: the unused code is now removed.
